### PR TITLE
chore(deps): update nuxt and valibot to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,11 @@
 				"drizzle-kit": "0.30.1",
 				"drizzle-orm": "0.38.3",
 				"modern-normalize": "3.0.1",
-				"nuxt": "3.15.1",
+				"nuxt": "3.15.2",
 				"pinia": "2.3.0",
 				"tsx": "4.19.2",
 				"ufo": "1.5.4",
-				"valibot": "1.0.0-beta.11",
+				"valibot": "1.0.0-beta.12",
 				"vue-tsc": "2.2.0",
 				"wrangler": "3.102.0",
 				"ws": "8.18.0"
@@ -498,9 +498,9 @@
 			}
 		},
 		"node_modules/@babel/standalone": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.26.5.tgz",
-			"integrity": "sha512-vXbSrFq1WauHvOg/XWcjkF6r7wDSHbN3+3Aro6LYjfODpGw8dCyqqbUMRX5LXlgzVAUrTSN6JkepFiHhLKHV5Q==",
+			"version": "7.26.6",
+			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.26.6.tgz",
+			"integrity": "sha512-h1mkoNFYCqDkS+vTLGzsQYvp1v1qbuugk4lOtb/oyjArZ+EtreAaxcSYg3rSIzWZRQOjx4iqGe7A8NRYIMSTTw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -618,6 +618,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -634,6 +635,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"darwin"
@@ -650,6 +652,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -666,6 +669,7 @@
 				"arm64"
 			],
 			"dev": true,
+			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
@@ -682,6 +686,7 @@
 				"x64"
 			],
 			"dev": true,
+			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"win32"
@@ -695,6 +700,7 @@
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -707,6 +713,7 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1622,6 +1629,7 @@
 			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
 			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=14"
 			}
@@ -1637,9 +1645,9 @@
 			}
 		},
 		"node_modules/@iconify/collections": {
-			"version": "1.0.505",
-			"resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.505.tgz",
-			"integrity": "sha512-v5sk7zCcHRcRY7y87wE0WGaZ74l328UBJzj3X6pC4VR5ao/FM7zUMpzkELXLeyVfFZWV2TZnsPKf6P7R1dXZlw==",
+			"version": "1.0.506",
+			"resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.506.tgz",
+			"integrity": "sha512-LaFH5SMolreU+n+i5lfTADj2b7S/syZkF8dP6oCt948gqoivJA1T3JZEHEUsJwYtWqRhYZQ1MuFziKmrTET8yA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1932,6 +1940,16 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/detect-libc": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -2084,6 +2102,82 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@nuxt/cli": {
+			"version": "3.20.0",
+			"resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.20.0.tgz",
+			"integrity": "sha512-TmQPjIHXJFPTssPMMFuLF48nr9cm6ctaNwrnhDFl4xLunfLR4rrMJNJAQhepWyukg970ZgokZVbUYMqf6eCnTQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"c12": "^2.0.1",
+				"chokidar": "^4.0.3",
+				"citty": "^0.1.6",
+				"clipboardy": "^4.0.0",
+				"consola": "^3.3.3",
+				"defu": "^6.1.4",
+				"fuse.js": "^7.0.0",
+				"giget": "^1.2.3",
+				"h3": "^1.13.0",
+				"httpxy": "^0.1.5",
+				"jiti": "^2.4.2",
+				"listhen": "^1.9.0",
+				"nypm": "^0.4.1",
+				"ofetch": "^1.4.1",
+				"ohash": "^1.1.4",
+				"pathe": "^2.0.1",
+				"perfect-debounce": "^1.0.0",
+				"pkg-types": "^1.3.0",
+				"scule": "^1.3.0",
+				"semver": "^7.6.3",
+				"std-env": "^3.8.0",
+				"tinyexec": "^0.3.2",
+				"ufo": "^1.5.4"
+			},
+			"bin": {
+				"nuxi": "bin/nuxi.mjs",
+				"nuxi-ng": "bin/nuxi.mjs",
+				"nuxt": "bin/nuxi.mjs",
+				"nuxt-cli": "bin/nuxi.mjs"
+			},
+			"engines": {
+				"node": "^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@nuxt/cli/node_modules/nypm": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.4.1.tgz",
+			"integrity": "sha512-1b9mihliBh8UCcKtcGRu//G50iHpjxIQVUqkdhPT/SDVE7KdJKoHXLS0heuYTQCx95dFqiyUbXZB9r8ikn+93g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"citty": "^0.1.6",
+				"consola": "^3.2.3",
+				"pathe": "^1.1.2",
+				"pkg-types": "^1.2.1",
+				"tinyexec": "^0.3.1",
+				"ufo": "^1.5.4"
+			},
+			"bin": {
+				"nypm": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": "^14.16.0 || >=16.10.0"
+			}
+		},
+		"node_modules/@nuxt/cli/node_modules/nypm/node_modules/pathe": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@nuxt/cli/node_modules/pathe": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
+			"integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@nuxt/devalue": {
 			"version": "2.0.2",
@@ -2271,35 +2365,36 @@
 			}
 		},
 		"node_modules/@nuxt/kit": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.15.1.tgz",
-			"integrity": "sha512-7cVWjzfz3L6CsZrg6ppDZa7zGrZxCSfZjEQDIvVFn4mFKtJlK9k2izf5EewL6luzWwIQojkZAC3iq/1wtgI0Xw==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.15.2.tgz",
+			"integrity": "sha512-nxiPJVz2fICcyBKlN5pL1IgZVejyArulREsS5HvAk07hijlYuZ5toRM8soLt51VQNpFd/PedL+Z1AlYu/bQCYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@nuxt/schema": "3.15.1",
+				"@nuxt/schema": "3.15.2",
 				"c12": "^2.0.1",
-				"consola": "^3.3.3",
+				"consola": "^3.4.0",
 				"defu": "^6.1.4",
 				"destr": "^2.0.3",
 				"globby": "^14.0.2",
-				"ignore": "^7.0.0",
+				"ignore": "^7.0.3",
 				"jiti": "^2.4.2",
 				"klona": "^2.0.6",
 				"knitwork": "^1.2.0",
-				"mlly": "^1.7.3",
+				"mlly": "^1.7.4",
 				"ohash": "^1.1.4",
-				"pathe": "^2.0.0",
-				"pkg-types": "^1.3.0",
+				"pathe": "^2.0.1",
+				"pkg-types": "^1.3.1",
 				"scule": "^1.3.0",
 				"semver": "^7.6.3",
+				"std-env": "^3.8.0",
 				"ufo": "^1.5.4",
 				"unctx": "^2.4.1",
-				"unimport": "^3.14.5",
+				"unimport": "^3.14.6",
 				"untyped": "^1.5.2"
 			},
 			"engines": {
-				"node": ">=18.20.5"
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@nuxt/kit/node_modules/pathe": {
@@ -2310,15 +2405,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@nuxt/schema": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.15.1.tgz",
-			"integrity": "sha512-n5kOHt8uUyUM9z4Wu/8tIZkBYh3KTCGvyruG6oD9bfeT4OaS21+X3M7XsTXFMe+eYBZA70IFFlWn1JJZIPsKeA==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.15.2.tgz",
+			"integrity": "sha512-cTHGbLTbrQ83B+7Mh0ggc5MzIp74o8KciA0boCiBJyK5uImH9QQNK6VgfwRWcTD5sj3WNKiIB1luOMom3LHgVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"consola": "^3.3.3",
+				"consola": "^3.4.0",
 				"defu": "^6.1.4",
-				"pathe": "^2.0.0",
+				"pathe": "^2.0.1",
 				"std-env": "^3.8.0"
 			},
 			"engines": {
@@ -2368,34 +2463,34 @@
 			"license": "MIT"
 		},
 		"node_modules/@nuxt/vite-builder": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.15.1.tgz",
-			"integrity": "sha512-b9uvLuRSgZy+pvU0rwHOpYo9XmAPibNGFEn0MeG6rUWVee9didV0Q5voAr+/1kq9bIbf6V0QFh9TE+4pCxZuMQ==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/@nuxt/vite-builder/-/vite-builder-3.15.2.tgz",
+			"integrity": "sha512-YtP6hIOKhqa1JhX0QzuULpA84lseO76bv5OqJzUl7yoaykhOkZjkEk9c20hamtMdoxhVeUAXGZJCsp9Ivjfb3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@nuxt/kit": "3.15.1",
+				"@nuxt/kit": "3.15.2",
 				"@rollup/plugin-replace": "^6.0.2",
 				"@vitejs/plugin-vue": "^5.2.1",
 				"@vitejs/plugin-vue-jsx": "^4.1.1",
 				"autoprefixer": "^10.4.20",
-				"consola": "^3.3.3",
+				"consola": "^3.4.0",
 				"cssnano": "^7.0.6",
 				"defu": "^6.1.4",
 				"esbuild": "^0.24.2",
 				"escape-string-regexp": "^5.0.0",
 				"externality": "^1.0.2",
 				"get-port-please": "^3.1.2",
-				"h3": "^1.13.0",
+				"h3": "^1.13.1",
 				"jiti": "^2.4.2",
 				"knitwork": "^1.2.0",
 				"magic-string": "^0.30.17",
-				"mlly": "^1.7.3",
+				"mlly": "^1.7.4",
 				"ohash": "^1.1.4",
-				"pathe": "^2.0.0",
+				"pathe": "^2.0.1",
 				"perfect-debounce": "^1.0.0",
-				"pkg-types": "^1.3.0",
-				"postcss": "^8.4.49",
+				"pkg-types": "^1.3.1",
+				"postcss": "^8.5.1",
 				"rollup-plugin-visualizer": "^5.13.1",
 				"std-env": "^3.8.0",
 				"ufo": "^1.5.4",
@@ -2407,7 +2502,7 @@
 				"vue-bundle-renderer": "^2.1.1"
 			},
 			"engines": {
-				"node": "^18.20.5 || ^20.9.0 || >=22.0.0"
+				"node": "^18.12.0 || ^20.9.0 || >=22.0.0"
 			},
 			"peerDependencies": {
 				"vue": "^3.3.4"
@@ -3014,19 +3109,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/watcher/node_modules/detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"detect-libc": "bin/detect-libc.js"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/@pinia/nuxt": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@pinia/nuxt/-/nuxt-0.9.0.tgz",
@@ -3079,21 +3161,21 @@
 			}
 		},
 		"node_modules/@redocly/config": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.17.1.tgz",
-			"integrity": "sha512-CEmvaJuG7pm2ylQg53emPmtgm4nW2nxBgwXzbVEHpGas/lGnMyN8Zlkgiz6rPw0unASg6VW3wlz27SOL5XFHYQ==",
+			"version": "0.20.1",
+			"resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.20.1.tgz",
+			"integrity": "sha512-TYiTDtuItiv95YMsrRxyCs1HKLrDPtTvpaD3+kDKXBnFDeJuYKZ+eHXpCr6YeN4inxfVBs7DLhHsQcs9srddyQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@redocly/openapi-core": {
-			"version": "1.27.1",
-			"resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.27.1.tgz",
-			"integrity": "sha512-zQ47/A+Drk2Y75/af69MD3Oad4H9LxkUDzcm7XBkyLNDKIWQrDKDnS5476oDq77+zciymNxgMVtxxVXlnGS8kw==",
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.27.2.tgz",
+			"integrity": "sha512-qVrDc27DHpeO2NRCMeRdb4299nijKQE3BY0wrA+WUHlOLScorIi/y7JzammLk22IaTvjR9Mv9aTAdjE1aUwJnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@redocly/ajv": "^8.11.2",
-				"@redocly/config": "^0.17.0",
+				"@redocly/config": "^0.20.1",
 				"colorette": "^1.2.0",
 				"https-proxy-agent": "^7.0.4",
 				"js-levenshtein": "^1.1.6",
@@ -3651,9 +3733,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "22.10.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-			"integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+			"version": "22.10.6",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
+			"integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3697,23 +3779,23 @@
 			}
 		},
 		"node_modules/@unhead/dom": {
-			"version": "1.11.15",
-			"resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.11.15.tgz",
-			"integrity": "sha512-2OZ7zvZQLqlqkhvsKsNOhxxoO3vgjygzzrmtooQR9QNKY+3HjwJ3+QfjGswXI976YV7VJem57ydQSMk1ijB7yg==",
+			"version": "1.11.18",
+			"resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.11.18.tgz",
+			"integrity": "sha512-zQuJUw/et9zYEV0SZWTDX23IgurwMaXycAuxt4L6OgNL0T4TWP3a0J/Vm3Q02hmdNo/cPKeVBrwBdnFUXjGU4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@unhead/schema": "1.11.15",
-				"@unhead/shared": "1.11.15"
+				"@unhead/schema": "1.11.18",
+				"@unhead/shared": "1.11.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/harlan-zw"
 			}
 		},
 		"node_modules/@unhead/schema": {
-			"version": "1.11.15",
-			"resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.11.15.tgz",
-			"integrity": "sha512-UkLz1dqw4yoh4jELEyLsgSG7yrXc+gv68GkQeTv8LysEPa8sXtFqhfuqTBLhY3sHqSnP8RkDknhtFhG2S3fuKQ==",
+			"version": "1.11.18",
+			"resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.11.18.tgz",
+			"integrity": "sha512-a3TA/OJCRdfbFhcA3Hq24k1ZU1o9szicESrw8DZcGyQFacHnh84mVgnyqSkMnwgCmfN4kvjSiTBlLEHS6+wATw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3725,13 +3807,13 @@
 			}
 		},
 		"node_modules/@unhead/shared": {
-			"version": "1.11.15",
-			"resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.11.15.tgz",
-			"integrity": "sha512-VT42ssmwpFGfixfXqAZ+Rn7KyNG0yFqWGsvLOXIgahiTzh3N1k2st1tPvuYFZU22dtWBNxG7cvy8yxUd1vunMQ==",
+			"version": "1.11.18",
+			"resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.11.18.tgz",
+			"integrity": "sha512-OsupRQRxJqqnuKiL1Guqipjbl7MndD5DofvmGa3PFGu2qNPmOmH2mxGFjRBBgq2XxY1KalIHl/2I9HV6gbK8cw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@unhead/schema": "1.11.15",
+				"@unhead/schema": "1.11.18",
 				"packrup": "^0.1.2"
 			},
 			"funding": {
@@ -3739,30 +3821,30 @@
 			}
 		},
 		"node_modules/@unhead/ssr": {
-			"version": "1.11.15",
-			"resolved": "https://registry.npmjs.org/@unhead/ssr/-/ssr-1.11.15.tgz",
-			"integrity": "sha512-btoJ7huldVdxOJOr9yx8DpDiUELzdlX3LB0k5cBub+CI4nZoPC/8ovuaYzKBriAIkEtQp9g9ytHRUJYDvim/1g==",
+			"version": "1.11.18",
+			"resolved": "https://registry.npmjs.org/@unhead/ssr/-/ssr-1.11.18.tgz",
+			"integrity": "sha512-uaHPz0RRAb18yKeCmHyHk5QKWRk/uHpOrqSbhRXTOhbrd3Ur3gGTVaAoyUoRYKGPU5B5/pyHh3TfLw0LkfrH1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@unhead/schema": "1.11.15",
-				"@unhead/shared": "1.11.15"
+				"@unhead/schema": "1.11.18",
+				"@unhead/shared": "1.11.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/harlan-zw"
 			}
 		},
 		"node_modules/@unhead/vue": {
-			"version": "1.11.15",
-			"resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.11.15.tgz",
-			"integrity": "sha512-2NT8Kph5AvB/qO+C8UKAc7cudbFRZTJk0eRpn8o1nG3yk2+mWvN0vsTTjnKvXixNF193I/R+zqo/NkcjgaWG9A==",
+			"version": "1.11.18",
+			"resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.11.18.tgz",
+			"integrity": "sha512-Jfi7t/XNBnlcauP9UTH3VHBcS69G70ikFd2e5zdgULLDRWpOlLs1sSTH1V2juNptc93DOk9RQfC5jLWbLcivFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@unhead/schema": "1.11.15",
-				"@unhead/shared": "1.11.15",
+				"@unhead/schema": "1.11.18",
+				"@unhead/shared": "1.11.18",
 				"hookable": "^5.5.3",
-				"unhead": "1.11.15"
+				"unhead": "1.11.18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/harlan-zw"
@@ -4231,6 +4313,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
 			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.11.0"
 			},
@@ -4467,6 +4550,7 @@
 			"resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
 			"integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"printable-characters": "^1.0.42"
 			}
@@ -4865,6 +4949,7 @@
 			"resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
 			"integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.1",
 				"tslib": "^2.2.0"
@@ -5142,9 +5227,9 @@
 			"license": "MIT"
 		},
 		"node_modules/consola": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-3.3.3.tgz",
-			"integrity": "sha512-Qil5KwghMzlqd51UXM0b6fyaGHtOC22scxrwrz4A2882LyUMwQjnvaedN1HAeXzphspQ6CpHkzMAWxBTUruDLg==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+			"integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5163,6 +5248,7 @@
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
 			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5235,9 +5321,9 @@
 			}
 		},
 		"node_modules/cronstrue": {
-			"version": "2.52.0",
-			"resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.52.0.tgz",
-			"integrity": "sha512-NKgHbWkSZXJUcaBHSsyzC8eegD6bBd4O0oCI6XMIJ+y4Bq3v4w7sY3wfWoKPuVlq9pQHRB6od0lmKpIqi8TlKA==",
+			"version": "2.53.0",
+			"resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.53.0.tgz",
+			"integrity": "sha512-CkAcaI94xL8h6N7cGxgXfR5D7oV2yVtDzB9vMZP8tIgPyEv/oc/7nq9rlk7LMxvc3N+q6LKZmNLCVxJRpyEg8A==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5475,7 +5561,8 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
 			"integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/db0": {
 			"version": "0.2.1",
@@ -5629,13 +5716,16 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
-			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"bin": {
+				"detect-libc": "bin/detect-libc.js"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/devalue": {
@@ -6344,9 +6434,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.80",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.80.tgz",
-			"integrity": "sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw==",
+			"version": "1.5.82",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.82.tgz",
+			"integrity": "sha512-Zq16uk1hfQhyGx5GpwPAYDwddJuSGhtRhgOA2mCxANYaDT79nAeGnaXogMGng4KqLaJUVnOnuL0+TDop9nLOiA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6571,6 +6661,7 @@
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
 			"integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			},
@@ -6787,9 +6878,9 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6866,6 +6957,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/fuse.js": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+			"integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -6898,6 +6999,7 @@
 			"resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
 			"integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
 			"dev": true,
+			"license": "Unlicense",
 			"dependencies": {
 				"data-uri-to-buffer": "^2.0.0",
 				"source-map": "^0.6.1"
@@ -6908,6 +7010,7 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7028,7 +7131,8 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/global-directory": {
 			"version": "4.0.1",
@@ -7228,9 +7332,9 @@
 			}
 		},
 		"node_modules/httpxy": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.1.5.tgz",
-			"integrity": "sha512-hqLDO+rfststuyEUTWObQK6zHEEmZ/kaIP2/zclGGZn6X8h/ESTWg+WKecQ/e5k4nPswjzZD+q2VqZIbr15CoQ==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.1.6.tgz",
+			"integrity": "sha512-GxJLI6oJZ3NbJl/vDlPmTCtP4WHwboNhGLHOcgf/3ia1QC5sdLglWbRHZwQjzjPuiCyw7MWwpwbsUfRDQlOdeg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7266,9 +7370,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.0.tgz",
-			"integrity": "sha512-lcX8PNQygAa22u/0BysEY8VhaFRzlOkvdlKczDPnJvrkJD1EuqzEky5VYYKM2iySIuaVIDv9N190DfSreSLw2A==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+			"integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8072,6 +8176,7 @@
 			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.2.tgz",
 			"integrity": "sha512-gFC3IaUKrLGdtA6y6PLpC/QE5YAjB5ITCfBZHkosRyFZ9ApaCHKcHRvrEFMc/R19QxxtHD+G3tExEHp7MmtsYQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"acorn": "^8.8.0",
@@ -8171,17 +8276,24 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
-			"integrity": "sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
+			"integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.14.0",
-				"pathe": "^1.1.2",
-				"pkg-types": "^1.2.1",
+				"pathe": "^2.0.1",
+				"pkg-types": "^1.3.0",
 				"ufo": "^1.5.4"
 			}
+		},
+		"node_modules/mlly/node_modules/pathe": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
+			"integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/modern-normalize": {
 			"version": "3.0.1",
@@ -8225,6 +8337,7 @@
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
 			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"mustache": "bin/mustache"
 			}
@@ -8540,45 +8653,30 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
-		"node_modules/nuxi": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/nuxi/-/nuxi-3.20.0.tgz",
-			"integrity": "sha512-E1R6QvUoinlAkP1EMesU0Dn1xLDLFli9LzaVAYdsmC2frHGIc15jMDRzwkAgK/8ae0H+tjHlfi/Qps/jZwF+7g==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"nuxi": "bin/nuxi.mjs",
-				"nuxi-ng": "bin/nuxi.mjs",
-				"nuxt": "bin/nuxi.mjs",
-				"nuxt-cli": "bin/nuxi.mjs"
-			},
-			"engines": {
-				"node": "^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/nuxt": {
-			"version": "3.15.1",
-			"resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.15.1.tgz",
-			"integrity": "sha512-8sKgqjhu5JoaVv89TnBW5S0jvsXRrEWGF+CguYUPK+6sRAtNcJAwcWxd4pEmURYQ2D0jjdfgr/VyH0i9CdhkBQ==",
+			"version": "3.15.2",
+			"resolved": "https://registry.npmjs.org/nuxt/-/nuxt-3.15.2.tgz",
+			"integrity": "sha512-1EiQ5wYYVhgkRyaMCyuc4R5lhJtOPJTdOe3LwYNbIol3pmcO1urhNDNKfhiy9zdcA3G14zzN0W/+TqXXidchRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@nuxt/cli": "^3.20.0",
 				"@nuxt/devalue": "^2.0.2",
 				"@nuxt/devtools": "^1.7.0",
-				"@nuxt/kit": "3.15.1",
-				"@nuxt/schema": "3.15.1",
-				"@nuxt/telemetry": "^2.6.2",
-				"@nuxt/vite-builder": "3.15.1",
-				"@unhead/dom": "^1.11.14",
-				"@unhead/shared": "^1.11.14",
-				"@unhead/ssr": "^1.11.14",
-				"@unhead/vue": "^1.11.14",
+				"@nuxt/kit": "3.15.2",
+				"@nuxt/schema": "3.15.2",
+				"@nuxt/telemetry": "^2.6.4",
+				"@nuxt/vite-builder": "3.15.2",
+				"@unhead/dom": "^1.11.18",
+				"@unhead/shared": "^1.11.18",
+				"@unhead/ssr": "^1.11.18",
+				"@unhead/vue": "^1.11.18",
 				"@vue/shared": "^3.5.13",
 				"acorn": "8.14.0",
 				"c12": "^2.0.1",
 				"chokidar": "^4.0.3",
 				"compatx": "^0.1.8",
-				"consola": "^3.3.3",
+				"consola": "^3.4.0",
 				"cookie-es": "^1.2.2",
 				"defu": "^6.1.4",
 				"destr": "^2.0.3",
@@ -8588,37 +8686,36 @@
 				"escape-string-regexp": "^5.0.0",
 				"estree-walker": "^3.0.3",
 				"globby": "^14.0.2",
-				"h3": "^1.13.0",
+				"h3": "^1.13.1",
 				"hookable": "^5.5.3",
-				"ignore": "^7.0.0",
+				"ignore": "^7.0.3",
 				"impound": "^0.2.0",
 				"jiti": "^2.4.2",
 				"klona": "^2.0.6",
 				"knitwork": "^1.2.0",
 				"magic-string": "^0.30.17",
-				"mlly": "^1.7.3",
+				"mlly": "^1.7.4",
 				"nanotar": "^0.1.1",
 				"nitropack": "^2.10.4",
-				"nuxi": "^3.17.2",
 				"nypm": "^0.4.1",
 				"ofetch": "^1.4.1",
 				"ohash": "^1.1.4",
-				"pathe": "^2.0.0",
+				"pathe": "^2.0.1",
 				"perfect-debounce": "^1.0.0",
-				"pkg-types": "^1.3.0",
+				"pkg-types": "^1.3.1",
 				"radix3": "^1.1.2",
 				"scule": "^1.3.0",
 				"semver": "^7.6.3",
 				"std-env": "^3.8.0",
-				"strip-literal": "^2.1.1",
+				"strip-literal": "^3.0.0",
 				"tinyglobby": "0.2.10",
 				"ufo": "^1.5.4",
 				"ultrahtml": "^1.5.3",
 				"uncrypto": "^0.1.3",
 				"unctx": "^2.4.1",
 				"unenv": "^1.10.0",
-				"unhead": "^1.11.14",
-				"unimport": "^3.14.5",
+				"unhead": "^1.11.18",
+				"unimport": "^3.14.6",
 				"unplugin": "^2.1.2",
 				"unplugin-vue-router": "^0.10.9",
 				"unstorage": "^1.14.4",
@@ -9183,16 +9280,23 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.0.tgz",
-			"integrity": "sha512-kS7yWjVFCkIw9hqdJBoMxDdzEngmkr5FXeWZZfQ6GoYacjVnsW6l2CcYW/0ThD0vF4LPJgVYnrg4d0uuhwYQbg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+			"integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"confbox": "^0.1.8",
-				"mlly": "^1.7.3",
-				"pathe": "^1.1.2"
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1"
 			}
+		},
+		"node_modules/pkg-types/node_modules/pathe": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
+			"integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pluralize": {
 			"version": "8.0.0",
@@ -9205,9 +9309,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.49",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-			"integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+			"version": "8.5.1",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+			"integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -9225,7 +9329,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.7",
+				"nanoid": "^3.3.8",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -9834,7 +9938,8 @@
 			"version": "1.0.42",
 			"resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-			"dev": true
+			"dev": true,
+			"license": "Unlicense"
 		},
 		"node_modules/process": {
 			"version": "0.11.10",
@@ -10674,6 +10779,7 @@
 			"resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
 			"integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
 			"dev": true,
+			"license": "Unlicense",
 			"dependencies": {
 				"as-table": "^1.0.36",
 				"get-source": "^2.0.12"
@@ -10708,6 +10814,7 @@
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4",
 				"npm": ">=6"
@@ -10810,9 +10917,9 @@
 			}
 		},
 		"node_modules/strip-literal": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-			"integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+			"integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11672,6 +11779,7 @@
 			"resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
 			"integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
 			},
@@ -11714,15 +11822,15 @@
 			}
 		},
 		"node_modules/unhead": {
-			"version": "1.11.15",
-			"resolved": "https://registry.npmjs.org/unhead/-/unhead-1.11.15.tgz",
-			"integrity": "sha512-fA0rYB7qMHKY4sg0yzEXhi0cqiF/nl/OUKNaXOS9ChJwCjJxabpZvmQIUOiGS+1ckoFbZc3qZnhDLpdeNhOQwg==",
+			"version": "1.11.18",
+			"resolved": "https://registry.npmjs.org/unhead/-/unhead-1.11.18.tgz",
+			"integrity": "sha512-TWgGUoZMpYe2yJwY6jZ0/9kpQT18ygr2h5lI6cUXdfD9UzDc0ytM9jGaleSYkj9guJWXkk7izYBnzJvxl8mRvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@unhead/dom": "1.11.15",
-				"@unhead/schema": "1.11.15",
-				"@unhead/shared": "1.11.15",
+				"@unhead/dom": "1.11.18",
+				"@unhead/schema": "1.11.18",
+				"@unhead/shared": "1.11.18",
 				"hookable": "^5.5.3"
 			},
 			"funding": {
@@ -11776,26 +11884,70 @@
 			}
 		},
 		"node_modules/unimport": {
-			"version": "3.14.5",
-			"resolved": "https://registry.npmjs.org/unimport/-/unimport-3.14.5.tgz",
-			"integrity": "sha512-tn890SwFFZxqaJSKQPPd+yygfKSATbM8BZWW1aCR2TJBTs1SDrmLamBueaFtYsGjHtQaRgqEbQflOjN2iW12gA==",
+			"version": "3.14.6",
+			"resolved": "https://registry.npmjs.org/unimport/-/unimport-3.14.6.tgz",
+			"integrity": "sha512-CYvbDaTT04Rh8bmD8jz3WPmHYZRG/NnvYVzwD6V1YAlvvKROlAeNDUBhkBGzNav2RKaeuXvlWYaa1V4Lfi/O0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rollup/pluginutils": "^5.1.3",
+				"@rollup/pluginutils": "^5.1.4",
 				"acorn": "^8.14.0",
 				"escape-string-regexp": "^5.0.0",
 				"estree-walker": "^3.0.3",
-				"fast-glob": "^3.3.2",
-				"local-pkg": "^0.5.1",
-				"magic-string": "^0.30.14",
-				"mlly": "^1.7.3",
-				"pathe": "^1.1.2",
+				"fast-glob": "^3.3.3",
+				"local-pkg": "^1.0.0",
+				"magic-string": "^0.30.17",
+				"mlly": "^1.7.4",
+				"pathe": "^2.0.1",
 				"picomatch": "^4.0.2",
-				"pkg-types": "^1.2.1",
+				"pkg-types": "^1.3.0",
 				"scule": "^1.3.0",
 				"strip-literal": "^2.1.1",
-				"unplugin": "^1.16.0"
+				"unplugin": "^1.16.1"
+			}
+		},
+		"node_modules/unimport/node_modules/js-tokens": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/unimport/node_modules/local-pkg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.0.0.tgz",
+			"integrity": "sha512-bbgPw/wmroJsil/GgL4qjDzs5YLTBMQ99weRsok1XCDccQeehbHA/I1oRvk2NPtr7KGZgT/Y5tPRnAtMqeG2Kg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mlly": "^1.7.3",
+				"pkg-types": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
+		},
+		"node_modules/unimport/node_modules/pathe": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.1.tgz",
+			"integrity": "sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/unimport/node_modules/strip-literal": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+			"integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^9.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/unimport/node_modules/unplugin": {
@@ -12207,9 +12359,9 @@
 			"license": "MIT"
 		},
 		"node_modules/valibot": {
-			"version": "1.0.0-beta.11",
-			"resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0-beta.11.tgz",
-			"integrity": "sha512-Ztl5Iks1Ql7Z6CwkS5oyqguN3G8tmUiNlsHpqbDt6DLMpm+eu+n8Q7f921gI3uHvNZ8xDVkd4cEJP5t+lELOfw==",
+			"version": "1.0.0-beta.12",
+			"resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0-beta.12.tgz",
+			"integrity": "sha512-j3WIxJ0pmUFMfdfUECn3YnZPYOiG0yHYcFEa/+RVgo0I+MXE3ToLt7gNRLtY5pwGfgNmsmhenGZfU5suu9ijUA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -13120,6 +13272,7 @@
 			"integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"workerd": "bin/workerd"
 			},
@@ -13139,6 +13292,7 @@
 			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.102.0.tgz",
 			"integrity": "sha512-Za4DstbS3+/hu+///K/4dFFeV6XbPBAGp7NCnVajchxRTwEPTdbO5eezH0HLJPMHK6G/0yIzyhlEMnyg4YzHAA==",
 			"dev": true,
+			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.3.4",
 				"@esbuild-plugins/node-globals-polyfill": "0.2.3",
@@ -13733,6 +13887,7 @@
 			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
 			"integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cookie": "^0.7.1",
 				"mustache": "^4.2.0",
@@ -13769,6 +13924,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
 			"integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
 		"drizzle-kit": "0.30.1",
 		"drizzle-orm": "0.38.3",
 		"modern-normalize": "3.0.1",
-		"nuxt": "3.15.1",
+		"nuxt": "3.15.2",
 		"pinia": "2.3.0",
 		"tsx": "4.19.2",
 		"ufo": "1.5.4",
-		"valibot": "1.0.0-beta.11",
+		"valibot": "1.0.0-beta.12",
 		"vue-tsc": "2.2.0",
 		"wrangler": "3.102.0",
 		"ws": "8.18.0"


### PR DESCRIPTION
- Bump nuxt from 3.15.1 to 3.15.2
- Bump valibot from 1.0.0-beta.11 to 1.0.0-beta.12