### PR TITLE
fix: remove initial value from InputDialog

### DIFF
--- a/apps/pepega/app/components/pages/account/TelegramChannelsCard.vue
+++ b/apps/pepega/app/components/pages/account/TelegramChannelsCard.vue
@@ -41,7 +41,6 @@
       header-text="Add Telegram channel"
       placeholder="perdTV"
       add-button-text="Add channel"
-      initial-value="woof"
       :minlength="5"
       :maxlength="32"
       v-model="isOpened"


### PR DESCRIPTION
- 🐶 Removed initial-value prop from InputDialog to prevent unintended default text.