### PR TITLE
fix(pepega): secure session logout

### DIFF
--- a/apps/pepega/server/__tests__/authentication.test.ts
+++ b/apps/pepega/server/__tests__/authentication.test.ts
@@ -1,0 +1,105 @@
+import { once } from 'node:events'
+import { createServer, type Server } from 'node:http'
+import { promisify } from 'node:util'
+import { createApp, createRouter, defineEventHandler, toNodeListener } from 'h3'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import apiSessionCheck from '../middleware/1.api-session-check'
+import { checkAdmin } from '../utils/admin'
+import { getSessionUser } from '../utils/user'
+
+describe('authentication', () => {
+  const findFirstUser = vi.fn()
+  const originalSessionSecret = process.env.SESSION_SECRET
+  let server: Server
+  let url: URL
+
+  beforeAll(async () => {
+    process.env.SESSION_SECRET = 'test-session-secret-with-enough-entropy'
+
+    const app = createApp()
+    const router = createRouter()
+
+    app.use(defineEventHandler((event) => {
+      Reflect.set(event.context, 'db', {
+        query: {
+          users: {
+            findFirst: findFirstUser
+          }
+        }
+      })
+    }))
+
+    app.use(apiSessionCheck)
+
+    router.get('/session-user', defineEventHandler(async (event) => {
+      return await getSessionUser(event)
+    }))
+
+    router.get('/admin-check', defineEventHandler(async (event) => {
+      return await checkAdmin(event, {
+        force: true
+      })
+    }))
+
+    router.get('/api/private', defineEventHandler(() => {
+      return 'authenticated'
+    }))
+
+    app.use(router)
+
+    server = createServer(toNodeListener(app))
+    server.listen(0, '127.0.0.1')
+
+    await once(server, 'listening')
+
+    const address = server.address()
+
+    if (address === null || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port')
+    }
+
+    url = new URL(`http://127.0.0.1:${address.port}`)
+  })
+
+  beforeEach(() => {
+    findFirstUser.mockClear()
+  })
+
+  afterAll(async () => {
+    if (originalSessionSecret === undefined) {
+      delete process.env.SESSION_SECRET
+    } else {
+      process.env.SESSION_SECRET = originalSessionSecret
+    }
+
+    const closeServer = promisify(server.close.bind(server))
+
+    await closeServer()
+  })
+
+  it('should reject an API request without an authenticated session', async () => {
+    const response = await fetch(new URL('/api/private', url))
+
+    expect(response.status).toBe(401)
+  })
+
+  it('should return the guest user without querying the database', async () => {
+    const response = await fetch(new URL('/session-user', url))
+    const user: unknown = await response.json()
+
+    expect(user).toStrictEqual({
+      id: null,
+      isAdmin: false,
+      isStreamer: false
+    })
+    expect(findFirstUser).not.toHaveBeenCalled()
+  })
+
+  it('should reject an admin check without querying the database', async () => {
+    const response = await fetch(new URL('/admin-check', url))
+    const isAdmin: unknown = await response.json()
+
+    expect(isAdmin).toBe(false)
+    expect(findFirstUser).not.toHaveBeenCalled()
+  })
+})

--- a/apps/pepega/server/middleware/1.api-session-check.ts
+++ b/apps/pepega/server/middleware/1.api-session-check.ts
@@ -25,7 +25,7 @@ export default defineEventHandler(async (event) => {
     const session = await getAppSession(event)
     const { userId } = session.data
 
-    if (userId === null) {
+    if (typeof userId !== 'string') {
       throw createError({
         statusCode: 401
       })

--- a/apps/pepega/server/utils/__tests__/session.test.ts
+++ b/apps/pepega/server/utils/__tests__/session.test.ts
@@ -1,0 +1,48 @@
+import { once } from 'node:events'
+import { createServer, type Server } from 'node:http'
+import { promisify } from 'node:util'
+import { createApp, defineEventHandler, toNodeListener } from 'h3'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { clearAppSession } from '../session'
+
+describe(clearAppSession, () => {
+  let server: Server
+  let url: URL
+
+  beforeAll(async () => {
+    const app = createApp()
+
+    app.use(defineEventHandler(async (event) => {
+      await clearAppSession(event)
+    }))
+
+    server = createServer(toNodeListener(app))
+    server.listen(0, '127.0.0.1')
+
+    await once(server, 'listening')
+
+    const address = server.address()
+
+    if (address === null || typeof address === 'string') {
+      throw new Error('Test server did not bind to a TCP port')
+    }
+
+    url = new URL(`http://127.0.0.1:${address.port}`)
+  })
+
+  afterAll(async () => {
+    const closeServer = promisify(server.close.bind(server))
+
+    await closeServer()
+  })
+
+  it('should expire the session cookie immediately', async () => {
+    const response = await fetch(url, {
+      method: 'POST'
+    })
+
+    expect(response.headers.getSetCookie()).toStrictEqual([
+      'pepeger=; Max-Age=0; Path=/; HttpOnly; Secure; SameSite=Strict'
+    ])
+  })
+})

--- a/apps/pepega/server/utils/admin.ts
+++ b/apps/pepega/server/utils/admin.ts
@@ -49,7 +49,7 @@ export async function checkAdmin(
   const session = await useAppSession(event)
   const { userId, isAdmin = false, lastAdminCheck } = session.data
 
-  if (userId === null) {
+  if (typeof userId !== 'string') {
     return false
   }
 

--- a/apps/pepega/server/utils/session.ts
+++ b/apps/pepega/server/utils/session.ts
@@ -7,7 +7,7 @@ interface SessionData {
   lastAdminCheck?: string;
 }
 
-function getSessionConfig() : SessionConfig {
+function getSessionConfig() {
   return {
     // TODO: use env validator
     password: process.env.SESSION_SECRET ?? '',
@@ -19,7 +19,7 @@ function getSessionConfig() : SessionConfig {
       secure: true,
       maxAge: 60 * 60 * 24 * 7 // 1 week
     }
-  }
+  } satisfies SessionConfig
 }
 
 export async function useAppSession(event: H3Event<EventHandlerRequest>) {
@@ -43,5 +43,12 @@ export async function updateAppSession(event: H3Event<EventHandlerRequest>, data
 export async function clearAppSession(event: H3Event<EventHandlerRequest>) {
   const config = getSessionConfig()
 
-  return clearSession(event, config)
+  return clearSession(event, {
+    ...config,
+
+    cookie: {
+      ...config.cookie,
+      maxAge: 0
+    }
+  })
 }

--- a/apps/pepega/server/utils/session.ts
+++ b/apps/pepega/server/utils/session.ts
@@ -2,8 +2,8 @@ import { clearSession, getSession, updateSession, useSession, type H3Event, type
 import { sessionCookieName } from '~~/constants';
 
 interface SessionData {
-  userId: string | null;
-  isAdmin: boolean;
+  userId?: string | null;
+  isAdmin?: boolean;
   lastAdminCheck?: string;
 }
 

--- a/apps/pepega/server/utils/user.ts
+++ b/apps/pepega/server/utils/user.ts
@@ -15,7 +15,7 @@ export async function getSessionUser(event: H3Event) : Promise<UserModel> {
   const session = await useAppSession(event)
   const { userId } = session.data
 
-  if (userId === null) {
+  if (typeof userId !== 'string') {
     return defaultUser
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,9 +6,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('apps/pepega/app', import.meta.url)),
-      '@@': import.meta.dirname,
+      '@@': fileURLToPath(new URL('apps/pepega', import.meta.url)),
       '~': fileURLToPath(new URL('apps/pepega/app', import.meta.url)),
-      '~~': import.meta.dirname,
+      '~~': fileURLToPath(new URL('apps/pepega', import.meta.url)),
       '#shared': fileURLToPath(new URL('apps/pepega/shared', import.meta.url)),
     },
   },


### PR DESCRIPTION
## Summary

Makes logout actually end the session and stops empty sessions from slipping through as a database user 🛡️🍪 No more week-long ghost cookie or mystery admin comeback 😎👍

- 🐛 Expire the session cookie immediately during logout
- 🛡️ Reject missing session user IDs before protected handlers and database queries
- ✅ Cover the exact logout cookie plus guest, admin, and private API behavior with regressions
- 🔧 Align Vitest root aliases with the Nuxt application for server utility tests

## Motivation

The logout response reused the seven-day cookie lifetime and retained an empty cookie. After that cookie disappeared, a new H3 session contained no `userId`; the existing `null`-only checks accepted its `undefined` value, and the Drizzle filter was omitted. A guest request could therefore resolve the first database user. The fix expires the cookie with `Max-Age=0` and rejects every session without a string user ID before querying the database 🌬️