### PR TITLE
fix(pepega): make logout idempotent

### DIFF
--- a/apps/pepega/constants.ts
+++ b/apps/pepega/constants.ts
@@ -4,7 +4,8 @@ export const sessionCookieName = 'pepeger'
 export const adminCheckInterval = 60 * 60 * 1000
 
 export const publicApiPaths = [
-  '/api/oauth/twitch'
+  '/api/oauth/twitch',
+  '/api/user/logout'
 ] as const
 
 export const webhooksWorkerBaseUrls = {

--- a/apps/pepega/server/__tests__/authentication.test.ts
+++ b/apps/pepega/server/__tests__/authentication.test.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from 'node:http'
 import { promisify } from 'node:util'
 import { createApp, createRouter, defineEventHandler, toNodeListener } from 'h3'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import logoutHandler from '../api/user/logout.post'
 import apiSessionCheck from '../middleware/1.api-session-check'
 import { checkAdmin } from '../utils/admin'
 import { getSessionUser } from '../utils/user'
@@ -45,6 +46,8 @@ describe('authentication', () => {
       return 'authenticated'
     }))
 
+    router.post('/api/user/logout', logoutHandler)
+
     app.use(router)
 
     server = createServer(toNodeListener(app))
@@ -81,6 +84,14 @@ describe('authentication', () => {
     const response = await fetch(new URL('/api/private', url))
 
     expect(response.status).toBe(401)
+  })
+
+  it('should allow logout without an authenticated session', async () => {
+    const response = await fetch(new URL('/api/user/logout', url), {
+      method: 'POST'
+    })
+
+    expect(response.status).toBe(204)
   })
 
   it('should return the guest user without querying the database', async () => {


### PR DESCRIPTION
## Summary

Lets logout finish even when the browser UI and server session have drifted apart 🐛🍪 The user can always clear stale local auth state instead of staring at a swallowed `401` 😎👍

- 🐛 Allow the logout API through session middleware without an authenticated session
- ✅ Cover unauthenticated logout with the real API handler

## Motivation

Live staging reproduced a stale authenticated Pinia state with no session cookie. Clicking logout returned `401`, the component swallowed the error, and the user stayed visually logged in. Making logout idempotent restores the expected `204` response and lets the existing client cleanup complete 🌬️